### PR TITLE
chore: harden gitignore for local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,10 @@
 /transformers
 /data
 .DS_Store
+myenv/
+__pycache__/
+**/__pycache__/
+*.py[cod]
+*.db
+*.idx
+*.pkl


### PR DESCRIPTION
## Summary
- ignore virtual environments, caches, and generated indexes
- prevent committing local database and Faiss artifacts