### PR TITLE
chore: supply branch protection script token

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Configure branch protection via REST API
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.BRANCH_PROTECT_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;


### PR DESCRIPTION
## Summary
- use the default workflow token for the branch protection script